### PR TITLE
Fix for overlapping tab elements on scaled-up UI.

### DIFF
--- a/Source/MainTabWindow_ResearchTree.cs
+++ b/Source/MainTabWindow_ResearchTree.cs
@@ -150,11 +150,10 @@ namespace FluffyResearchTree
         {
             // tree view rects, have to deal with UIScale and ZoomLevel manually.
             _baseViewRect = new Rect(
-                StandardMargin                                            / Prefs.UIScale,
-                ( TopBarHeight + Constants.Margin + StandardMargin )      / Prefs.UIScale,
-                ( Screen.width                    - StandardMargin * 2f ) / Prefs.UIScale,
-                ( Screen.height - MainButtonDef.ButtonHeight - StandardMargin * 2f - TopBarHeight - Constants.Margin ) /
-                Prefs.UIScale );
+                StandardMargin / Prefs.UIScale,
+                (TopBarHeight + Constants.Margin + StandardMargin),
+                (Screen.width - StandardMargin * 2f) / Prefs.UIScale,
+                ((Screen.height - MainButtonDef.ButtonHeight - StandardMargin * 2) / Prefs.UIScale) - TopBarHeight - Constants.Margin);
             _baseViewRect_Inner = _baseViewRect.ContractedBy( Constants.Margin / Prefs.UIScale );
 
             // windowrect, set to topleft (for some reason vanilla alignment overlaps bottom buttons).


### PR DESCRIPTION
When the UI scale is set to 2x and above on high-DPI displays, the tree rect on the main research tab overlaps the top bar, frequently blocking access to the search field. This is my attempt at solving it. It seems to work well on every UI scale as well.